### PR TITLE
Updated module version to avoid installation compatibility error upon installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "msp/antivirus": "1.3.1",
         "msp/nospam": "1.3.0",
         "msp/adminrestriction": "1.3.0",
-        "msp/recaptcha": "1.4.8",
-        "msp/twofactorauth": "2.1.9",
+        "msp/recaptcha": "^2.0",
+        "msp/twofactorauth": "^3.0",
         "msp/passwd": "1.2.0"
     },
     "authors": [


### PR DESCRIPTION
This PR solve this error while running `composer require msp/security-suite`:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove magento/product-enterprise-edition 2.3.1
    - Conclusion: don't install magento/product-enterprise-edition 2.3.1
    - msp/security-suite 2.1.7 requires msp/twofactorauth 2.1.11 -> satisfiable by msp/twofactorauth[2.1.11].
    - Conclusion: don't install msp/twofactorauth 2.1.11
    - msp/security-suite 2.1.6 requires msp/twofactorauth 2.1.9 -> satisfiable by msp/twofactorauth[2.1.9].
    - Conclusion: don't install msp/twofactorauth 2.1.9
    - msp/security-suite 2.1.5 requires msp/twofactorauth 2.1.6 -> satisfiable by msp/twofactorauth[2.1.6].
    - Conclusion: don't install msp/twofactorauth 2.1.6
    - Installation request for magento/product-enterprise-edition 2.3.1 -> satisfiable by magento/product-enterprise-edition[2.3.1].
    - msp/security-suite 2.1.4 requires msp/twofactorauth 2.1.3 -> satisfiable by msp/twofactorauth[2.1.3].
    - Conclusion: don't install msp/twofactorauth 2.1.3
    - magento/product-enterprise-edition 2.3.1 requires msp/twofactorauth 3.0.0 -> satisfiable by msp/twofactorauth[3.0.0].
    - Can only install one of: msp/twofactorauth[2.1.2, 3.0.0].
    - Can only install one of: msp/twofactorauth[2.1.2, 3.0.0].
    - Can only install one of: msp/twofactorauth[2.1.2, 3.0.0].
    - msp/security-suite 2.1.3 requires msp/twofactorauth 2.1.2 -> satisfiable by msp/twofactorauth[2.1.2].
    - Installation request for msp/security-suite ^2.1 -> satisfiable by msp/security-suite[2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.1.7].


Installation failed, reverting ./composer.json to its original content.
```